### PR TITLE
fix: Configure Tailwind v4 dark mode variant

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,3 @@
 @import "tailwindcss";
+
+@variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
### Summary

Behebt das Problem, dass Komponenten nicht auf Theme-Änderungen reagieren, indem die Tailwind v4 dark mode Variante korrekt konfiguriert wird.

### Änderungen

- Fügt `@variant dark` Direktive zu `src/index.css` hinzu
- Ermöglicht `dark:` Utility-Klassen korrekt auf die `.dark` Klasse am document root zu reagieren

### Testing

1. Toggle den Dark Mode Button im Header
2. Alle Komponenten sollten nun zwischen hellem und dunklem Theme wechseln
3. Die Präferenz wird in localStorage gespeichert

Closes #9

---
Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/iMarcintosh/claude-test/actions/runs/21482339607) | [Branch: claude/issue-9-20260129-1437](https://github.com/iMarcintosh/claude-test/tree/claude/issue-9-20260129-1437